### PR TITLE
4.2.0 mapr 1601 fix sparkmain

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -22,11 +22,11 @@
     <parent>
         <groupId>org.apache.oozie</groupId>
         <artifactId>oozie-main</artifactId>
-        <version>4.2.0-mapr</version>
+        <version>4.2.0-mapr-1601</version>
     </parent>
     <groupId>org.apache.oozie</groupId>
     <artifactId>oozie-client</artifactId>
-    <version>4.2.0-mapr</version>
+    <version>4.2.0-mapr-1601</version>
     <description>Apache Oozie Client</description>
     <name>Apache Oozie Client</name>
     <packaging>jar</packaging>

--- a/client/src/main/bin/oozie
+++ b/client/src/main/bin/oozie
@@ -125,7 +125,8 @@ OOZIE_CLIENT_OPTS="${OOZIE_CLIENT_OPTS} ${MAPR_SSL_OPTS}"
 if [ "$MAPR_SECURITY_STATUS" = "true" ]; then
   OOZIE_CLIENT_OPTS="${OOZIE_CLIENT_OPTS} -Dauthenticator.class=com.mapr.security.maprauth.MaprAuthenticator"
 fi
-
+#MAPR 21848 - Disable retry HTTP POST command
+OOZIE_CLIENT_OPTS="${OOZIE_CLIENT_OPTS} -Dsun.net.http.retryPost=false"
 while [[ ${1} =~ ^\-D ]]; do
   OOZIE_CLIENT_OPTS="${OOZIE_CLIENT_OPTS} ${1}"
   shift

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -22,11 +22,11 @@
     <parent>
         <groupId>org.apache.oozie</groupId>
         <artifactId>oozie-main</artifactId>
-        <version>4.2.0-mapr</version>
+        <version>4.2.0-mapr-1601</version>
     </parent>
     <groupId>org.apache.oozie</groupId>
     <artifactId>oozie-core</artifactId>
-    <version>4.2.0-mapr</version>
+    <version>4.2.0-mapr-1601</version>
     <description>Apache Oozie Core</description>
     <name>Apache Oozie Core</name>
     <packaging>jar</packaging>

--- a/core/src/main/java/org/apache/oozie/action/hadoop/JavaActionExecutor.java
+++ b/core/src/main/java/org/apache/oozie/action/hadoop/JavaActionExecutor.java
@@ -411,7 +411,7 @@ public class JavaActionExecutor extends ActionExecutor {
         String reduceOpts = conf.get(HADOOP_REDUCE_JAVA_OPTS);
         String childOpts = conf.get(HADOOP_CHILD_JAVA_OPTS);
         String amChildOpts = conf.get(YARN_AM_COMMAND_OPTS);
-        String oozieJavaTmpDirSetting = JAVA_TMP_DIR_SETTINGS + "/tmp";
+        String oozieJavaTmpDirSetting = JAVA_TMP_DIR_SETTINGS + "./tmp";
         if (childOpts == null) {
             conf.set(HADOOP_CHILD_JAVA_OPTS, oozieJavaTmpDirSetting);
         } else {

--- a/core/src/main/java/org/apache/oozie/action/hadoop/JavaActionExecutor.java
+++ b/core/src/main/java/org/apache/oozie/action/hadoop/JavaActionExecutor.java
@@ -411,7 +411,7 @@ public class JavaActionExecutor extends ActionExecutor {
         String reduceOpts = conf.get(HADOOP_REDUCE_JAVA_OPTS);
         String childOpts = conf.get(HADOOP_CHILD_JAVA_OPTS);
         String amChildOpts = conf.get(YARN_AM_COMMAND_OPTS);
-        String oozieJavaTmpDirSetting = JAVA_TMP_DIR_SETTINGS + System.getProperty("user.dir") + "/tmp";
+        String oozieJavaTmpDirSetting = JAVA_TMP_DIR_SETTINGS + "/tmp";
         if (childOpts == null) {
             conf.set(HADOOP_CHILD_JAVA_OPTS, oozieJavaTmpDirSetting);
         } else {

--- a/core/src/main/java/org/apache/oozie/workflow/lite/LiteWorkflowInstance.java
+++ b/core/src/main/java/org/apache/oozie/workflow/lite/LiteWorkflowInstance.java
@@ -41,6 +41,9 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.oozie.service.LiteWorkflowStoreService.LiteActionHandler;
+import org.apache.oozie.service.LiteWorkflowStoreService.LiteControlNodeHandler;
 
 //TODO javadoc
 public class LiteWorkflowInstance implements Writable, WorkflowInstance {
@@ -51,6 +54,7 @@ public class LiteWorkflowInstance implements Writable, WorkflowInstance {
     private static String PATH_SEPARATOR = "/";
     private static String ROOT = PATH_SEPARATOR;
     private static String TRANSITION_SEPARATOR = "#";
+    public static final String OK = "OK";
 
     // Using unique string to indicate version. This is to make sure that it
     // doesn't match with user data.
@@ -152,9 +156,9 @@ public class LiteWorkflowInstance implements Writable, WorkflowInstance {
     private Configuration conf;
     private String instanceId;
     private Status status;
-    private Map<String, NodeInstance> executionPaths = new HashMap<String, NodeInstance>();
-    private Map<String, String> persistentVars = new HashMap<String, String>();
-    private Map<String, Object> transientVars = new HashMap<String, Object>();
+    private Map<String, NodeInstance> executionPaths = new ConcurrentHashMap<String, NodeInstance>();
+    private Map<String, String> persistentVars = new ConcurrentHashMap<String, String>();
+    private Map<String, Object> transientVars = new ConcurrentHashMap<String, Object>();
 
     protected LiteWorkflowInstance() {
         log = XLog.getLog(getClass());
@@ -231,7 +235,20 @@ public class LiteWorkflowInstance implements Writable, WorkflowInstance {
             if (exiting) {
                 List<String> pathsToStart = new ArrayList<String>();
                 List<String> fullTransitions;
+                final List<String> transitions = context.getNodeDef().getTransitions();
                 try {
+                    if (!transitions.contains(signalValue) && !transitions.isEmpty() &&
+                      !context.getNodeDef().getHandlerClass().equals(LiteControlNodeHandler.class) && OK.equals(signalValue)) {
+                        nodeHandler = new LiteActionHandler();
+                        log.debug(XLog.STD, "Reinitialize Action Handler");
+                    }
+                    // This is additional log if bug will reproduce again
+                    for (Map.Entry<String, NodeInstance> entry : executionPaths.entrySet()) {
+                        log.debug(XLog.STD, "Execution paths: path [{0}], node name [{1}]", entry.getKey(), entry.getValue().nodeName);
+                    }
+                    log.debug(XLog.STD, "Current context transitions: [{0}]", transitions);
+                    log.debug(XLog.STD, "Name of current process node: [{0}]", nodeJob.nodeName);
+                    log.debug(XLog.STD, "NodeHandler class for this node: [{0}]", nodeHandler.getClass().getCanonicalName());
                     fullTransitions = nodeHandler.multiExit(context);
                     int last = fullTransitions.size() - 1;
                     // TEST THIS

--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -22,11 +22,11 @@
     <parent>
         <groupId>org.apache.oozie</groupId>
         <artifactId>oozie-main</artifactId>
-        <version>4.2.0-mapr</version>
+        <version>4.2.0-mapr-1601</version>
     </parent>
     <groupId>org.apache.oozie</groupId>
     <artifactId>oozie-distro</artifactId>
-    <version>4.2.0-mapr</version>
+    <version>4.2.0-mapr-1601</version>
     <description>Apache Oozie Distro</description>
     <name>Apache Oozie Distro</name>
     <packaging>jar</packaging>

--- a/distro/src/main/bin/addtowar.sh
+++ b/distro/src/main/bin/addtowar.sh
@@ -212,9 +212,9 @@ function getHadoopJars() {
       maprJars=$maprJars:libprotodefs*.jar
   fi
 
-  # MapR change - add json*.jar to the hadoopJars list.
-  if [[ -n $(find ${maprLib} -name "json-*.jar" -print) ]]; then
-      maprJars=$maprJars:json-*.jar
+  # MapR change - add json-smart*.jar to the hadoopJars list.
+  if [[ -n $(find ${maprLib} -name "json-smart*.jar" -print) ]]; then
+      maprJars=$maprJars:json-smart*.jar
   fi
 
   # MapR change - add zookeeper*.jar to the hadoopJars list.

--- a/distro/src/main/bin/oozie-setup.sh
+++ b/distro/src/main/bin/oozie-setup.sh
@@ -297,7 +297,8 @@ else
 
   # MAPR-21606 Automate installing extjs
   if [ ! -f "${libext}/ext-2.2.zip" ]; then
-    wget -q -c -O ${libext}/ext-2.2.zip http://dev.sencha.com/deploy/ext-2.2.zip
+    cd ${libext}
+    wget -q -c http://dev.sencha.com/deploy/ext-2.2.zip || echo "ExtJS could not be downloaded! Oozie UI will be disabled!"
   fi
 
   if [ -d "${libext}" ]; then

--- a/distro/src/main/bin/oozie-setup.sh
+++ b/distro/src/main/bin/oozie-setup.sh
@@ -189,13 +189,6 @@ if [ -e ${hadoopVersionFile} ]; then
   addBothHadoopJars=true
 fi
 
-if [ -e "${CATALINA_PID}" ]; then
-  ${BASEDIR}/bin/oozied.sh stop
-  if [ -f "${CATALINA_PID}" ]; then
-    rm -f "${CATALINA_PID}"
-  fi
-fi
-
 while [ $# -gt 0 ]
 do
   if [ "$1" = "sharelib" ] || [ "$1" = "db" ]; then
@@ -276,6 +269,13 @@ do
   fi
   shift
 done
+
+if [ -e "${CATALINA_PID}" ]; then
+  ${BASEDIR}/bin/oozied.sh stop
+  if [ -f "${CATALINA_PID}" ]; then
+    rm -f "${CATALINA_PID}"
+  fi
+fi
 
 if [ "${prepareWar}${addHadoopJars}" == "" ]; then
   echo "no arguments given"

--- a/distro/src/main/bin/oozie-setup.sh
+++ b/distro/src/main/bin/oozie-setup.sh
@@ -295,6 +295,11 @@ else
     libext=${additionalDir}
   fi
 
+  # MAPR-21606 Automate installing extjs
+  if [ ! -f "${libext}/ext-2.2.zip" ]; then
+    wget -q -c -O ${libext}/ext-2.2.zip http://dev.sencha.com/deploy/ext-2.2.zip
+  fi
+
   if [ -d "${libext}" ]; then
     if [ `ls ${libext} | grep \.jar\$ | wc -c` != 0 ]; then
       for i in "${libext}/"*.jar; do

--- a/distro/src/main/bin/oozied.sh
+++ b/distro/src/main/bin/oozied.sh
@@ -195,14 +195,15 @@ setup_oozie() {
 
     # default share dir
     directory=/oozie/share
-
-    if hadoop fs -test -d ${directory} ; then
-      hadoop fs -rmr ${directory}
-    fi
-    if [ "${mode}" == "1" ]; then
-      ${BASEDIR}/bin/oozie-setup.sh sharelib create -fs maprfs:/// -locallib ${BASEDIR}/share1
-    else
-      ${BASEDIR}/bin/oozie-setup.sh sharelib create -fs maprfs:/// -locallib ${BASEDIR}/share2
+    hadoop fs -test -d ${directory}
+    if [ $? != 0 ]
+    then
+      hadoop fs -mkdir -p $directory
+      if [ "${mode}" == "1" ]; then
+        ${BASEDIR}/bin/oozie-setup.sh sharelib create -fs maprfs:/// -locallib ${BASEDIR}/share1
+      else
+        ${BASEDIR}/bin/oozie-setup.sh sharelib create -fs maprfs:/// -locallib ${BASEDIR}/share2
+      fi
     fi
 
   fi

--- a/distro/src/main/bin/oozied.sh
+++ b/distro/src/main/bin/oozied.sh
@@ -161,6 +161,14 @@ setup_catalina_opts() {
   export CATALINA_OPTS="${CATALINA_OPTS} ${catalina_opts}"
 }
 
+setup_oozie_sharelib() {
+   if [ "${mode}" == "1" ]; then
+      ${BASEDIR}/bin/oozie-setup.sh sharelib create -fs maprfs:/// -locallib ${BASEDIR}/share1
+   else
+      ${BASEDIR}/bin/oozie-setup.sh sharelib create -fs maprfs:/// -locallib ${BASEDIR}/share2
+   fi
+}
+
 setup_oozie() {
   if [ "${mode}" != "" ]; then
     # This means we are operating with MapR >= 4.0.1 and need to copy over correct war before startup.
@@ -188,6 +196,7 @@ setup_oozie() {
 
     # If needed, copy the correct oozie war over.
     if [ ! -e ${CATALINA_BASE}/webapps/oozie.war -o "${mode}" != "${oozie_hadoop_version}" -o ${OOZIE_HOME}/oozie-hadoop${mode}.war -nt ${CATALINA_BASE}/webapps/oozie.war ]; then
+      setup_oozie_sharelib
       cp ${OOZIE_HOME}/oozie-hadoop${mode}.war ${CATALINA_BASE}/webapps/oozie.war
       rm -rf ${CATALINA_BASE}/webapps/oozie
       echo "oozie_hadoop_version=${mode}" > ${oozie_hadoop_version_file}
@@ -199,11 +208,7 @@ setup_oozie() {
     if [ $? != 0 ]
     then
       hadoop fs -mkdir -p $directory
-      if [ "${mode}" == "1" ]; then
-        ${BASEDIR}/bin/oozie-setup.sh sharelib create -fs maprfs:/// -locallib ${BASEDIR}/share1
-      else
-        ${BASEDIR}/bin/oozie-setup.sh sharelib create -fs maprfs:/// -locallib ${BASEDIR}/share2
-      fi
+      setup_oozie_sharelib
     fi
 
   fi

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -22,11 +22,11 @@
     <parent>
         <groupId>org.apache.oozie</groupId>
         <artifactId>oozie-main</artifactId>
-        <version>4.2.0-mapr</version>
+        <version>4.2.0-mapr-1601</version>
     </parent>
     <groupId>org.apache.oozie</groupId>
     <artifactId>oozie-docs</artifactId>
-    <version>4.2.0-mapr</version>
+    <version>4.2.0-mapr-1601</version>
     <description>Apache Oozie Docs</description>
     <name>Apache Oozie Docs</name>
     <packaging>war</packaging>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -22,11 +22,11 @@
     <parent>
         <groupId>org.apache.oozie</groupId>
         <artifactId>oozie-main</artifactId>
-        <version>4.2.0-mapr</version>
+        <version>4.2.0-mapr-1601</version>
     </parent>
     <groupId>org.apache.oozie</groupId>
     <artifactId>oozie-examples</artifactId>
-    <version>4.2.0-mapr</version>
+    <version>4.2.0-mapr-1601</version>
     <description>Apache Oozie Examples</description>
     <name>Apache Oozie Examples</name>
     <packaging>jar</packaging>

--- a/examples/src/main/apps/hive/script.q
+++ b/examples/src/main/apps/hive/script.q
@@ -15,5 +15,6 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 --
+DROP TABLE test;
 CREATE EXTERNAL TABLE test (a INT) STORED AS TEXTFILE LOCATION '${INPUT}';
 INSERT OVERWRITE DIRECTORY '${OUTPUT}' SELECT * FROM test;

--- a/hadooplibs/hadoop-auth-0.23/pom.xml
+++ b/hadooplibs/hadoop-auth-0.23/pom.xml
@@ -22,12 +22,12 @@
     <parent>
         <groupId>org.apache.oozie</groupId>
         <artifactId>oozie-main</artifactId>
-        <version>4.2.0-mapr</version>
+        <version>4.2.0-mapr-1601</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>org.apache.oozie</groupId>
     <artifactId>oozie-hadoop-auth</artifactId>
-    <version>hadoop-0.23-4.2.0-mapr</version>
+    <version>hadoop-0.23-4.2.0-mapr-1601</version>
     <description>Apache Oozie Hadoop Auth</description>
     <name>Apache Oozie Hadoop Auth ${project.version} Test</name>
     <packaging>jar</packaging>

--- a/hadooplibs/hadoop-auth-1/pom.xml
+++ b/hadooplibs/hadoop-auth-1/pom.xml
@@ -22,12 +22,12 @@
     <parent>
         <groupId>org.apache.oozie</groupId>
         <artifactId>oozie-main</artifactId>
-        <version>4.2.0-mapr</version>
+        <version>4.2.0-mapr-1601</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>org.apache.oozie</groupId>
     <artifactId>oozie-hadoop-auth</artifactId>
-    <version>hadoop-1-4.2.0-mapr</version>
+    <version>hadoop-1-4.2.0-mapr-1601</version>
     <description>Apache Oozie Hadoop Auth</description>
     <name>Apache Oozie Hadoop Auth ${project.version}</name>
     <packaging>jar</packaging>

--- a/hadooplibs/hadoop-auth-2/pom.xml
+++ b/hadooplibs/hadoop-auth-2/pom.xml
@@ -22,12 +22,12 @@
     <parent>
         <groupId>org.apache.oozie</groupId>
         <artifactId>oozie-main</artifactId>
-        <version>4.2.0-mapr</version>
+        <version>4.2.0-mapr-1601</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>org.apache.oozie</groupId>
     <artifactId>oozie-hadoop-auth</artifactId>
-    <version>hadoop-2-4.2.0-mapr</version>
+    <version>hadoop-2-4.2.0-mapr-1601</version>
     <description>Apache Oozie Hadoop</description>
     <name>Apache Oozie Hadoop Auth ${project.version} Test</name>
     <packaging>jar</packaging>

--- a/hadooplibs/hadoop-distcp-0.23/pom.xml
+++ b/hadooplibs/hadoop-distcp-0.23/pom.xml
@@ -22,12 +22,12 @@
     <parent>
         <groupId>org.apache.oozie</groupId>
         <artifactId>oozie-main</artifactId>
-        <version>4.2.0-mapr</version>
+        <version>4.2.0-mapr-1601</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>org.apache.oozie</groupId>
     <artifactId>oozie-hadoop-distcp</artifactId>
-    <version>hadoop-0.23-4.2.0-mapr</version>
+    <version>hadoop-0.23-4.2.0-mapr-1601</version>
     <description>Apache Oozie Hadoop Distcp ${project.version}</description>
     <name>Apache Oozie Hadoop Distcp ${project.version}</name>
     <packaging>jar</packaging>

--- a/hadooplibs/hadoop-distcp-1/pom.xml
+++ b/hadooplibs/hadoop-distcp-1/pom.xml
@@ -22,12 +22,12 @@
     <parent>
         <groupId>org.apache.oozie</groupId>
         <artifactId>oozie-main</artifactId>
-        <version>4.2.0-mapr</version>
+        <version>4.2.0-mapr-1601</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>org.apache.oozie</groupId>
     <artifactId>oozie-hadoop-distcp</artifactId>
-    <version>hadoop-1-4.2.0-mapr</version>
+    <version>hadoop-1-4.2.0-mapr-1601</version>
     <description>Apache Oozie Hadoop Distcp ${project.version}</description>
     <name>Apache Oozie Hadoop Distcp ${project.version}</name>
     <packaging>jar</packaging>

--- a/hadooplibs/hadoop-distcp-2/pom.xml
+++ b/hadooplibs/hadoop-distcp-2/pom.xml
@@ -22,12 +22,12 @@
     <parent>
         <groupId>org.apache.oozie</groupId>
         <artifactId>oozie-main</artifactId>
-        <version>4.2.0-mapr</version>
+        <version>4.2.0-mapr-1601</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>org.apache.oozie</groupId>
     <artifactId>oozie-hadoop-distcp</artifactId>
-    <version>hadoop-2-4.2.0-mapr</version>
+    <version>hadoop-2-4.2.0-mapr-1601</version>
     <description>Apache Oozie Hadoop Distcp ${project.version}</description>
     <name>Apache Oozie Hadoop Distcp ${project.version}</name>
     <packaging>jar</packaging>

--- a/hadooplibs/hadoop-distcp-3/pom.xml
+++ b/hadooplibs/hadoop-distcp-3/pom.xml
@@ -22,12 +22,12 @@
     <parent>
         <groupId>org.apache.oozie</groupId>
         <artifactId>oozie-main</artifactId>
-        <version>4.2.0-mapr</version>
+        <version>4.2.0-mapr-1601</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>org.apache.oozie</groupId>
     <artifactId>oozie-hadoop-distcp</artifactId>
-    <version>hadoop-3-4.2.0-mapr</version>
+    <version>hadoop-3-4.2.0-mapr-1601</version>
     <description>Apache Oozie Hadoop Distcp ${project.version}</description>
     <name>Apache Oozie Hadoop Distcp ${project.version}</name>
     <packaging>jar</packaging>

--- a/hadooplibs/hadoop-utils-0.23/pom.xml
+++ b/hadooplibs/hadoop-utils-0.23/pom.xml
@@ -22,12 +22,12 @@
     <parent>
         <groupId>org.apache.oozie</groupId>
         <artifactId>oozie-main</artifactId>
-        <version>4.2.0-mapr</version>
+        <version>4.2.0-mapr-1601</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>org.apache.oozie</groupId>
     <artifactId>oozie-hadoop-utils</artifactId>
-    <version>hadoop-0.23-4.2.0-mapr</version>
+    <version>hadoop-0.23-4.2.0-mapr-1601</version>
     <description>Apache Oozie Hadoop Utils</description>
     <name>Apache Oozie Hadoop Utils</name>
     <packaging>jar</packaging>

--- a/hadooplibs/hadoop-utils-1/pom.xml
+++ b/hadooplibs/hadoop-utils-1/pom.xml
@@ -22,12 +22,12 @@
     <parent>
         <groupId>org.apache.oozie</groupId>
         <artifactId>oozie-main</artifactId>
-        <version>4.2.0-mapr</version>
+        <version>4.2.0-mapr-1601</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>org.apache.oozie</groupId>
     <artifactId>oozie-hadoop-utils</artifactId>
-    <version>hadoop-1-4.2.0-mapr</version>
+    <version>hadoop-1-4.2.0-mapr-1601</version>
     <description>Apache Oozie Hadoop Utils</description>
     <name>Apache Oozie Hadoop Utils</name>
     <packaging>jar</packaging>

--- a/hadooplibs/hadoop-utils-2/pom.xml
+++ b/hadooplibs/hadoop-utils-2/pom.xml
@@ -22,12 +22,12 @@
     <parent>
         <groupId>org.apache.oozie</groupId>
         <artifactId>oozie-main</artifactId>
-        <version>4.2.0-mapr</version>
+        <version>4.2.0-mapr-1601</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>org.apache.oozie</groupId>
     <artifactId>oozie-hadoop-utils</artifactId>
-    <version>hadoop-2-4.2.0-mapr</version>
+    <version>hadoop-2-4.2.0-mapr-1601</version>
     <description>Apache Oozie Hadoop Utils ${project.version}</description>
     <name>Apache Oozie Hadoop Utils ${project.version}</name>
     <packaging>jar</packaging>

--- a/hadooplibs/hadoop-utils-3/pom.xml
+++ b/hadooplibs/hadoop-utils-3/pom.xml
@@ -22,12 +22,12 @@
     <parent>
         <groupId>org.apache.oozie</groupId>
         <artifactId>oozie-main</artifactId>
-        <version>4.2.0-mapr</version>
+        <version>4.2.0-mapr-1601</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <groupId>org.apache.oozie</groupId>
     <artifactId>oozie-hadoop-utils</artifactId>
-    <version>hadoop-3-4.2.0-mapr</version>
+    <version>hadoop-3-4.2.0-mapr-1601</version>
     <description>Apache Oozie Hadoop Utils ${project.version}</description>
     <name>Apache Oozie Hadoop Utils ${project.version}</name>
     <packaging>jar</packaging>

--- a/hadooplibs/pom.xml
+++ b/hadooplibs/pom.xml
@@ -22,11 +22,11 @@
     <parent>
         <groupId>org.apache.oozie</groupId>
         <artifactId>oozie-main</artifactId>
-        <version>4.2.0-mapr</version>
+        <version>4.2.0-mapr-1601</version>
     </parent>
     <groupId>org.apache.oozie</groupId>
     <artifactId>oozie-hadooplibs</artifactId>
-    <version>4.2.0-mapr</version>
+    <version>4.2.0-mapr-1601</version>
     <description>Apache Oozie Hadoop Libs</description>
     <name>Apache Oozie Hadoop Libs</name>
     <packaging>pom</packaging>

--- a/login/pom.xml
+++ b/login/pom.xml
@@ -22,11 +22,11 @@
     <parent>
         <groupId>org.apache.oozie</groupId>
         <artifactId>oozie-main</artifactId>
-        <version>4.2.0-mapr</version>
+        <version>4.2.0-mapr-1601</version>
     </parent>
     <groupId>org.apache.oozie</groupId>
     <artifactId>oozie-login</artifactId>
-    <version>4.2.0-mapr</version>
+    <version>4.2.0-mapr-1601</version>
     <description>Apache Oozie Login</description>
     <name>Apache Oozie Login</name>
     <packaging>war</packaging>

--- a/minitest/pom.xml
+++ b/minitest/pom.xml
@@ -23,12 +23,12 @@
     <parent>
         <groupId>org.apache.oozie</groupId>
         <artifactId>oozie-main</artifactId>
-        <version>4.2.0-mapr</version>
+        <version>4.2.0-mapr-1601</version>
     </parent>
 
     <groupId>org.apache.oozie.test</groupId>
     <artifactId>oozie-mini</artifactId>
-    <version>4.2.0-mapr</version>
+    <version>4.2.0-mapr-1601</version>
     <description>Apache Oozie MiniOozie</description>
     <name>Apache Oozie MiniOozie</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.apache.oozie</groupId>
     <artifactId>oozie-main</artifactId>
-    <version>4.2.0-mapr</version>
+    <version>4.2.0-mapr-1601</version>
     <description>Apache Oozie Main</description>
     <name>Apache Oozie Main</name>
     <packaging>pom</packaging>
@@ -86,11 +86,11 @@
 
          <!-- Sharelib component versions -->
         <!-- Pig and Hive version must be changed after release -->
-         <hive.version>1.2.0-mapr</hive.version>
+         <hive.version>1.2.0-mapr-1601</hive.version>
          <pig.version>0.15.0-mapr-1508</pig.version>
          <pig.classifier></pig.classifier>
          <pig-2.classifier>h2</pig-2.classifier>
-         <sqoop.version>1.4.6-mapr</sqoop.version>
+         <sqoop.version>1.4.6-mapr-1601</sqoop.version>
          <spark.version>1.4.1</spark.version>
          <spark.guava.version>14.0.1</spark.guava.version>
          <sqoop.classifier>hadoop100</sqoop.classifier>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
 
          <!-- Sharelib component versions -->
         <!-- Pig and Hive version must be changed after release -->
-         <hive.version>1.2.0-mapr-1508</hive.version>
+         <hive.version>1.2.0-mapr-1510</hive.version>
          <pig.version>0.15.0-mapr-1508</pig.version>
          <pig.classifier></pig.classifier>
          <pig-2.classifier>h2</pig-2.classifier>
@@ -498,6 +498,19 @@
                 <artifactId>oozie-hadoop-distcp</artifactId>
                 <version>${hadooplib.version}</version>
                 <scope>provided</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.hive.hcatalog</groupId>
+                <artifactId>hive-hcatalog-core</artifactId>
+                <version>${hive.version}</version>
+                <scope>provided</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.hive</groupId>
+                        <artifactId>hive-cli</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1417,7 +1417,6 @@
                 <groupId>org.apache.sqoop</groupId>
                 <artifactId>sqoop</artifactId>
                 <version>${sqoop.version}</version>
-                <classifier>${sqoop.classifier}</classifier>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -86,11 +86,11 @@
 
          <!-- Sharelib component versions -->
         <!-- Pig and Hive version must be changed after release -->
-         <hive.version>1.2.0-mapr-1510</hive.version>
+         <hive.version>1.2.0-mapr</hive.version>
          <pig.version>0.15.0-mapr-1508</pig.version>
          <pig.classifier></pig.classifier>
          <pig-2.classifier>h2</pig-2.classifier>
-         <sqoop.version>1.4.6</sqoop.version>
+         <sqoop.version>1.4.6-mapr</sqoop.version>
          <spark.version>1.4.1</spark.version>
          <spark.guava.version>14.0.1</spark.guava.version>
          <sqoop.classifier>hadoop100</sqoop.classifier>

--- a/sharelib/distcp/pom.xml
+++ b/sharelib/distcp/pom.xml
@@ -22,12 +22,12 @@
     <parent>
         <groupId>org.apache.oozie</groupId>
         <artifactId>oozie-main</artifactId>
-        <version>4.2.0-mapr</version>
+        <version>4.2.0-mapr-1601</version>
         <relativePath>../..</relativePath>
     </parent>
     <groupId>org.apache.oozie</groupId>
     <artifactId>oozie-sharelib-distcp</artifactId>
-    <version>4.2.0-mapr</version>
+    <version>4.2.0-mapr-1601</version>
     <description>Apache Oozie Share Lib Distcp</description>
     <name>Apache Oozie Share Lib Distcp</name>
     <packaging>jar</packaging>

--- a/sharelib/hcatalog/pom.xml
+++ b/sharelib/hcatalog/pom.xml
@@ -22,12 +22,12 @@
     <parent>
         <groupId>org.apache.oozie</groupId>
         <artifactId>oozie-main</artifactId>
-        <version>4.2.0-mapr</version>
+        <version>4.2.0-mapr-1601</version>
         <relativePath>../..</relativePath>
     </parent>
     <groupId>org.apache.oozie</groupId>
     <artifactId>oozie-sharelib-hcatalog</artifactId>
-    <version>4.2.0-mapr</version>
+    <version>4.2.0-mapr-1601</version>
     <description>Apache Oozie Share Lib HCatalog</description>
     <name>Apache Oozie Share Lib HCatalog</name>
     <packaging>jar</packaging>

--- a/sharelib/hive/pom.xml
+++ b/sharelib/hive/pom.xml
@@ -22,12 +22,12 @@
     <parent>
         <groupId>org.apache.oozie</groupId>
         <artifactId>oozie-main</artifactId>
-        <version>4.2.0-mapr</version>
+        <version>4.2.0-mapr-1601</version>
         <relativePath>../..</relativePath>
     </parent>
     <groupId>org.apache.oozie</groupId>
     <artifactId>oozie-sharelib-hive</artifactId>
-    <version>4.2.0-mapr</version>
+    <version>4.2.0-mapr-1601</version>
     <description>Apache Oozie Share Lib Hive</description>
     <name>Apache Oozie Share Lib Hive</name>
     <packaging>jar</packaging>

--- a/sharelib/hive/src/main/java/org/apache/oozie/action/hadoop/HiveMain.java
+++ b/sharelib/hive/src/main/java/org/apache/oozie/action/hadoop/HiveMain.java
@@ -68,7 +68,7 @@ public class HiveMain extends LauncherMain {
         run(HiveMain.class, args);
     }
 
-    private static Configuration initActionConf() {
+    private static Configuration initActionConf() throws java.io.IOException {
         // Loading action conf prepared by Oozie
         Configuration hiveConf = new Configuration(false);
 
@@ -116,7 +116,9 @@ public class HiveMain extends LauncherMain {
         // to force hive to use the jobclient to submit the job, never using HADOOPBIN (to do localmode)
         hiveConf.setBoolean("hive.exec.mode.local.auto", false);
 
-        hiveConf.set("hive.querylog.location", "./hivelogs");
+        String pwd = new java.io.File("").getCanonicalPath();
+        hiveConf.set("hive.querylog.location", pwd + File.separator + "hivetmp" + File.separator + "querylog");
+        hiveConf.set("hive.exec.local.scratchdir", pwd + File.separator + "hivetmp" + File.separator + "scratchdir");
 
         return hiveConf;
     }

--- a/sharelib/hive2/pom.xml
+++ b/sharelib/hive2/pom.xml
@@ -22,12 +22,12 @@
     <parent>
         <groupId>org.apache.oozie</groupId>
         <artifactId>oozie-main</artifactId>
-        <version>4.2.0-mapr</version>
+        <version>4.2.0-mapr-1601</version>
         <relativePath>../..</relativePath>
     </parent>
     <groupId>org.apache.oozie</groupId>
     <artifactId>oozie-sharelib-hive2</artifactId>
-    <version>4.2.0-mapr</version>
+    <version>4.2.0-mapr-1601</version>
     <description>Apache Oozie Share Lib Hive 2</description>
     <name>Apache Oozie Share Lib Hive 2</name>
     <packaging>jar</packaging>

--- a/sharelib/oozie/pom.xml
+++ b/sharelib/oozie/pom.xml
@@ -22,12 +22,12 @@
     <parent>
         <groupId>org.apache.oozie</groupId>
         <artifactId>oozie-main</artifactId>
-        <version>4.2.0-mapr</version>
+        <version>4.2.0-mapr-1601</version>
         <relativePath>../..</relativePath>
     </parent>
     <groupId>org.apache.oozie</groupId>
     <artifactId>oozie-sharelib-oozie</artifactId>
-    <version>4.2.0-mapr</version>
+    <version>4.2.0-mapr-1601</version>
     <description>Apache Oozie Share Lib Oozie</description>
     <name>Apache Oozie Share Lib Oozie</name>
     <packaging>jar</packaging>

--- a/sharelib/pig/pom.xml
+++ b/sharelib/pig/pom.xml
@@ -22,12 +22,12 @@
     <parent>
         <groupId>org.apache.oozie</groupId>
         <artifactId>oozie-main</artifactId>
-        <version>4.2.0-mapr</version>
+        <version>4.2.0-mapr-1601</version>
         <relativePath>../..</relativePath>
     </parent>
     <groupId>org.apache.oozie</groupId>
     <artifactId>oozie-sharelib-pig</artifactId>
-    <version>4.2.0-mapr</version>
+    <version>4.2.0-mapr-1601</version>
     <description>Apache Oozie Share Lib Pig</description>
     <name>Apache Oozie Share Lib Pig</name>
     <packaging>jar</packaging>

--- a/sharelib/pig2/pom.xml
+++ b/sharelib/pig2/pom.xml
@@ -22,12 +22,12 @@
     <parent>
         <groupId>org.apache.oozie</groupId>
         <artifactId>oozie-main</artifactId>
-        <version>4.2.0-mapr</version>
+        <version>4.2.0-mapr-1601</version>
         <relativePath>../..</relativePath>
     </parent>
     <groupId>org.apache.oozie</groupId>
     <artifactId>oozie-sharelib-pig2</artifactId>
-    <version>4.2.0-mapr</version>
+    <version>4.2.0-mapr-1601</version>
     <description>Apache Oozie Share Lib Pig</description>
     <name>Apache Oozie Share Lib Pig</name>
     <packaging>jar</packaging>
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>org.apache.pig</groupId>
             <artifactId>pig</artifactId>
-            <version>0.15.0-mapr-SNAPSHOT</version>
+            <version>${pig.version}</version>
             <classifier>${pig-2.classifier}</classifier>
             <scope>compile</scope>
         </dependency>

--- a/sharelib/pom.xml
+++ b/sharelib/pom.xml
@@ -37,6 +37,7 @@
         <module>pig</module>
         <module>pig2</module>
         <module>hive</module>
+        <module>hive2</module>
         <module>sqoop</module>
         <module>oozie</module>
         <module>distcp</module>
@@ -111,9 +112,6 @@
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>
-            <modules>
-                <module>hive2</module>
-            </modules>
             <build>
                 <plugins>
                     <plugin>

--- a/sharelib/pom.xml
+++ b/sharelib/pom.xml
@@ -22,11 +22,11 @@
     <parent>
         <groupId>org.apache.oozie</groupId>
         <artifactId>oozie-main</artifactId>
-        <version>4.2.0-mapr</version>
+        <version>4.2.0-mapr-1601</version>
     </parent>
     <groupId>org.apache.oozie</groupId>
     <artifactId>oozie-sharelib</artifactId>
-    <version>4.2.0-mapr</version>
+    <version>4.2.0-mapr-1601</version>
     <description>Apache Oozie Share Lib</description>
     <name>Apache Oozie Share Lib</name>
     <packaging>pom</packaging>

--- a/sharelib/spark/pom.xml
+++ b/sharelib/spark/pom.xml
@@ -22,12 +22,12 @@
     <parent>
         <groupId>org.apache.oozie</groupId>
         <artifactId>oozie-main</artifactId>
-        <version>4.2.0-mapr</version>
+        <version>4.2.0-mapr-1601</version>
         <relativePath>../..</relativePath>
     </parent>
     <groupId>org.apache.oozie</groupId>
     <artifactId>oozie-sharelib-spark</artifactId>
-    <version>4.2.0-mapr</version>
+    <version>4.2.0-mapr-1601</version>
     <description>Apache Oozie Share Lib Spark</description>
     <name>Apache Oozie Share Lib Spark</name>
     <packaging>jar</packaging>

--- a/sharelib/spark/src/main/java/org.apache.oozie.action.hadoop/SparkMain.java
+++ b/sharelib/spark/src/main/java/org.apache.oozie.action.hadoop/SparkMain.java
@@ -63,14 +63,33 @@ public class SparkMain extends LauncherMain {
             sparkArgs.add(CLASS_NAME_OPTION);
             sparkArgs.add(className);
         }
-
-        String sparkOpts = actionConf.get(SparkActionExecutor.SPARK_OPTS);
-        if (StringUtils.isNotEmpty(sparkOpts)) {
-            String[] sparkOptions = sparkOpts.split(DELIM);
-            for (String opt : sparkOptions) {
-                sparkArgs.add(opt);
-            }
-        }
+String sparkOpts = actionConf.get(SparkActionExecutor.SPARK_OPTS);
+          if (StringUtils.isNotEmpty(sparkOpts)) {
+              String[] sparkOptions = sparkOpts.split(DELIM);
+              boolean quoted = false;
+              String quotedOpt = null;
+              for (String opt : sparkOptions) {
+                  //if (!quoted) sparkArgs.add(opt);
+                  if (!quoted && opt.charAt(0) == '"' && opt.charAt(opt.length()-1) == '"') {
+                    quotedOpt = opt.substring(1, opt.length()-1);
+                    sparkArgs.add(quotedOpt);
+                  }
+                  else if (!quoted && opt.charAt(0) == '"' && opt.charAt(opt.length()-1) != '"') {
+                      quotedOpt = opt;
+                      quoted = true;
+                  }
+                  else if (quoted && opt.charAt(opt.length()-1) != '"') {
+                      quotedOpt += " " + opt;
+                  }
+                  else if (quoted && opt.charAt(opt.length()-1) == '"') {
+                      quotedOpt += " " + opt;
+                      quotedOpt = quotedOpt.substring(1, quotedOpt.length() - 1);
+                      sparkArgs.add(quotedOpt);
+                      quoted = false;
+                  }
+                  else if (!quoted) sparkArgs.add(opt);
+              }
+          }
 
         if (!sparkArgs.contains(VERBOSE_OPTION)) {
             sparkArgs.add(VERBOSE_OPTION);

--- a/sharelib/sqoop/pom.xml
+++ b/sharelib/sqoop/pom.xml
@@ -22,12 +22,12 @@
     <parent>
         <groupId>org.apache.oozie</groupId>
         <artifactId>oozie-main</artifactId>
-        <version>4.2.0-mapr</version>
+        <version>4.2.0-mapr-1601</version>
         <relativePath>../..</relativePath>
     </parent>
     <groupId>org.apache.oozie</groupId>
     <artifactId>oozie-sharelib-sqoop</artifactId>
-    <version>4.2.0-mapr</version>
+    <version>4.2.0-mapr-1601</version>
     <description>Apache Oozie Share Lib Sqoop</description>
     <name>Apache Oozie Share Lib Sqoop</name>
     <packaging>jar</packaging>

--- a/sharelib/sqoop/pom.xml
+++ b/sharelib/sqoop/pom.xml
@@ -42,7 +42,6 @@
             <groupId>org.apache.sqoop</groupId>
             <artifactId>sqoop</artifactId>
             <scope>compile</scope>
-            <classifier>${sqoop.classifier}</classifier>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.hadoop</groupId>

--- a/sharelib/streaming/pom.xml
+++ b/sharelib/streaming/pom.xml
@@ -22,12 +22,12 @@
     <parent>
         <groupId>org.apache.oozie</groupId>
         <artifactId>oozie-main</artifactId>
-        <version>4.2.0-mapr</version>
+        <version>4.2.0-mapr-1601</version>
         <relativePath>../..</relativePath>
     </parent>
     <groupId>org.apache.oozie</groupId>
     <artifactId>oozie-sharelib-streaming</artifactId>
-    <version>4.2.0-mapr</version>
+    <version>4.2.0-mapr-1601</version>
     <description>Apache Oozie Share Lib Streaming</description>
     <name>Apache Oozie Share Lib Streaming</name>
     <packaging>jar</packaging>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -22,11 +22,11 @@
     <parent>
         <groupId>org.apache.oozie</groupId>
         <artifactId>oozie-main</artifactId>
-        <version>4.2.0-mapr</version>
+        <version>4.2.0-mapr-1601</version>
     </parent>
     <groupId>org.apache.oozie</groupId>
     <artifactId>oozie-tools</artifactId>
-    <version>4.2.0-mapr</version>
+    <version>4.2.0-mapr-1601</version>
     <description>Apache Oozie Tools</description>
     <name>Apache Oozie Tools</name>
     <packaging>jar</packaging>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -62,6 +62,18 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.hive.hcatalog</groupId>
+            <artifactId>hive-webhcat-java-client</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hive.hcatalog</groupId>
+            <artifactId>hive-hcatalog-core</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.oozie</groupId>
             <artifactId>oozie-core</artifactId>
             <scope>compile</scope>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -22,11 +22,11 @@
     <parent>
         <groupId>org.apache.oozie</groupId>
         <artifactId>oozie-main</artifactId>
-        <version>4.2.0-mapr</version>
+        <version>4.2.0-mapr-1601</version>
     </parent>
     <groupId>org.apache.oozie</groupId>
     <artifactId>oozie-webapp</artifactId>
-    <version>4.2.0-mapr</version>
+    <version>4.2.0-mapr-1601</version>
     <description>Apache Oozie WebApp</description>
     <name>Apache Oozie WebApp</name>
     <packaging>war</packaging>

--- a/workflowgenerator/pom.xml
+++ b/workflowgenerator/pom.xml
@@ -24,12 +24,12 @@
   <parent>
     <groupId>org.apache.oozie</groupId>
     <artifactId>oozie-main</artifactId>
-    <version>4.2.0-mapr</version>
+    <version>4.2.0-mapr-1601</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.oozie</groupId>
   <artifactId>oozie-workflowgenerator</artifactId>
-  <version>4.2.0-mapr</version>
+  <version>4.2.0-mapr-1601</version>
   <packaging>war</packaging>
   <description>Apache Oozie WorkflowGenerator</description>
   <name>Apache Oozie WorkflowGenerator</name>

--- a/zookeeper-security-tests/pom.xml
+++ b/zookeeper-security-tests/pom.xml
@@ -22,11 +22,11 @@
     <parent>
         <groupId>org.apache.oozie</groupId>
         <artifactId>oozie-main</artifactId>
-        <version>4.2.0-mapr</version>
+        <version>4.2.0-mapr-1601</version>
     </parent>
     <groupId>org.apache.oozie</groupId>
     <artifactId>oozie-zookeeper-security-tests</artifactId>
-    <version>4.2.0-mapr</version>
+    <version>4.2.0-mapr-1601</version>
     <description>Apache Oozie ZooKeeper Security Tests</description>
     <name>Apache Oozie ZooKeeper Security Tests</name>
     <packaging>jar</packaging>


### PR DESCRIPTION
In the current release (4.2.0), Oozie's Spark action still cannot accept the value of the "--conf" option with double quotation. For instance, in Spark-submit, the value of `--conf "xxx"` is allowed, whereas in Oozie it is not allowed, and this is required sometimes anyway in practice
